### PR TITLE
remove unused import errors

### DIFF
--- a/object/acdbdictionarywdflt.go
+++ b/object/acdbdictionarywdflt.go
@@ -1,7 +1,6 @@
 package object
 
 import (
-	"errors"
 	"fmt"
 	"github.com/yofu/dxf/format"
 	"github.com/yofu/dxf/handle"

--- a/object/dictionary.go
+++ b/object/dictionary.go
@@ -1,7 +1,6 @@
 package object
 
 import (
-	"errors"
 	"fmt"
 	"github.com/yofu/dxf/format"
 	"github.com/yofu/dxf/handle"


### PR DESCRIPTION
I should have checked for unused imports before creating pull request #2. This removes the two unused import "errors" lines due to commit aaffb02 cleanups.