### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/drawing/drawing.go
+++ b/drawing/drawing.go
@@ -322,7 +322,7 @@ func (d *Drawing) Group(name, desc string, es ...entity.Entity) (*object.Group, 
 	return g, nil
 }
 
-// AddGroup adds given entities to the named group.
+// AddToGroup adds given entities to the named group.
 // If the named group doesn't exist, returns error.
 func (d *Drawing) AddToGroup(name string, es ...entity.Entity) error {
 	if g, exist := d.Groups[name]; exist {

--- a/entity/text.go
+++ b/entity/text.go
@@ -113,7 +113,7 @@ func (t *Text) FlipHorizontal() {
 	t.togglegenflag(2)
 }
 
-// FlipHorizontal flips Text vertically.
+// FlipVertical flips Text vertically.
 func (t *Text) FlipVertical() {
 	t.togglegenflag(4)
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?