### PR TITLE
refactor: improve error about line and entity type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/yofu/dxf
+
+go 1.22


### PR DESCRIPTION
The parsing error now points to the start string of the entity, not the end. Also, the unsupported entity error contains its type.

### Related PRs:
- [ ] https://github.com/yofu/dxf/pull/20